### PR TITLE
Categories queryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ struct
 
 `Post.categories` - List all associated tags with the module
 
+`Post.categories_queryable` - Same as `Post.categories` but it returns a `queryable` instead of a list.
+
 `Post.tagged_with_category(tag)` - Search for all resources tagged with
 the given tag
 
@@ -104,6 +106,8 @@ If you want you can use directly a set of functions to play with tags:
 [`Taglet.remove/3`](https://hexdocs.pm/taglet/Taglet.html#remove/3)
 
 [`Taglet.tag_list/2`](https://hexdocs.pm/taglet/Taglet.html#tag_list/2)
+
+[`Taglet.tag_list_queryable/2`](https://hexdocs.pm/taglet/Taglet.html#tag_list_queryable/2)
 
 [`Taglet.tagged_with/3`](https://hexdocs.pm/taglet/Taglet.html#tagged_with/3)
 

--- a/lib/taglet.ex
+++ b/lib/taglet.ex
@@ -116,15 +116,30 @@ defmodule Taglet do
   - With a module: it returns all the tags associated to one module and context.
   """
   @spec tag_list(taggable, context) :: tag_list
-  def tag_list(taggable, context \\ "tags")
-  def tag_list(struct, context) when is_map(struct) do
+  def tag_list(taggable, context \\ "tags") do
+    taggable
+    |> tag_list_queryable(context)
+    |> @repo.all
+  end
+
+  @doc """
+  It works exactly like tag_list but return a queryable
+
+  You can pass as first argument an struct or a module (phoenix model)
+
+  - With a struct: it returns the list of tags associated to that struct and context.
+  - With a module: it returns all the tags associated to one module and context.
+  """
+  @spec tag_list_queryable(taggable, context) :: Ecto.Queryable.t
+  def tag_list_queryable(taggable, context \\ "tags")
+  def tag_list_queryable(struct, context) when is_map(struct) do
     id = struct.id
     type = struct.__struct__ |> taggable_type
 
-    TagletQuery.search_tags(context, type, id) |> @repo.all
+    TagletQuery.search_tags(context, type, id)
   end
-  def tag_list(model, context) do
-    TagletQuery.search_tags(context, taggable_type(model)) |> @repo.all
+  def tag_list_queryable(model, context) do
+    TagletQuery.search_tags(context, taggable_type(model))
   end
 
   @doc """

--- a/lib/taglet/tag_as.ex
+++ b/lib/taglet/tag_as.ex
@@ -24,6 +24,10 @@ defmodule Taglet.TagAs do
         Taglet.tag_list(__MODULE__, unquote(context))
       end
 
+      def unquote(:"#{context}_queryable")() do
+        Taglet.tag_list_queryable(__MODULE__, unquote(context))
+      end
+
       def unquote(:"tagged_with_#{singularized_context}")(tag) do
         Taglet.tagged_with(tag, __MODULE__, unquote(context))
       end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Taglet.Mixfile do
 
   def project do
     [app: :taglet,
-     version: "0.4.1",
+     version: "0.4.2",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -49,7 +49,7 @@ defmodule Taglet.Mixfile do
     [
       name: :taglet,
       files: ["lib", "mix.exs", "README*", "LICENSE*"],
-      maintainers: ["itsquall"],
+      maintainers: ["itsquall", "abmm"],
       licenses: ["Apache License 2.0"],
       links: %{
         "GitHub" => "https://github.com/bizneo/taglet",

--- a/test/taglet/tag_as_test.exs
+++ b/test/taglet/tag_as_test.exs
@@ -29,6 +29,16 @@ defmodule Taglet.TagAsTest do
     assert result.categories == ["mycategory", "yourcategory"]
   end
 
+  test "using the module allows to add tags and list it as a queryable" do
+    post = @repo.insert!(%Post{title: "hello world"})
+
+    Post.add_categories(post, ["mycategory", "yourcategory"])
+    queryable = Post.categories_queryable
+
+    assert queryable.__struct__ == Ecto.Query
+    assert queryable |> @repo.all == ["mycategory", "yourcategory"]
+  end
+
   test "using the module allows to add a tag and list it" do
     post = @repo.insert!(%Post{title: "hello world"})
     Post.add_category(post, "mycategory")
@@ -48,6 +58,21 @@ defmodule Taglet.TagAsTest do
 
     assert tag_result      == ["mytag"]
     assert category_result == ["mycategory"]
+  end
+
+  test "using the module allows to add a tag and list it as queryable for different contexts" do
+    post = @repo.insert!(%Post{title: "hello world"})
+    Post.add_category(post, "mycategory")
+    Post.add_tag(post, "mytag")
+
+    tag_queryable      = Post.tags_queryable
+    category_queryable = Post.categories_queryable
+
+    assert tag_queryable.__struct__      == Ecto.Query
+    assert category_queryable.__struct__ == Ecto.Query
+
+    assert tag_queryable |> @repo.all      == ["mytag"]
+    assert category_queryable |> @repo.all == ["mycategory"]
   end
 
   test "using the module allows to remove a tag and list it" do


### PR DESCRIPTION
This PR adds a new method `tag_list_queryable` that works exactly like `tag_list` but return a queryable instead of a list of tags.