### PR TITLE
5 add multi tenancy capabilities with ecto meta prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CircleCI](https://circleci.com/gh/bizneo/taglet/tree/master.svg?style=svg)](https://circleci.com/gh/bizneo/taglet/tree/master)
-
 # Taglet
+
+[![CircleCI](https://circleci.com/gh/bizneo/taglet/tree/master.svg?style=svg)](https://circleci.com/gh/bizneo/taglet/tree/master)
 
 Taglet allows you to manage tags associated to your records.
 
@@ -107,18 +107,19 @@ concatenate ecto queries and return the query.
 
 
 ## Working with functions
+
 If you want you can use directly a set of functions to play with tags:
 
-[`Taglet.add/3`](https://hexdocs.pm/taglet/Taglet.html#add/3)
+[`Taglet.add/4`](https://hexdocs.pm/taglet/Taglet.html#add/4)
 
-[`Taglet.remove/3`](https://hexdocs.pm/taglet/Taglet.html#remove/3)
+[`Taglet.remove/4`](https://hexdocs.pm/taglet/Taglet.html#remove/4)
 
-[`Taglet.rename/4`](https://hexdocs.pm/taglet/Taglet.html#rename/4)
+[`Taglet.rename/5`](https://hexdocs.pm/taglet/Taglet.html#rename/5)
 
-[`Taglet.tag_list/2`](https://hexdocs.pm/taglet/Taglet.html#tag_list/2)
+[`Taglet.tag_list/3`](https://hexdocs.pm/taglet/Taglet.html#tag_list/3)
 
 [`Taglet.tag_list_queryable/2`](https://hexdocs.pm/taglet/Taglet.html#tag_list_queryable/2)
 
-[`Taglet.tagged_with/3`](https://hexdocs.pm/taglet/Taglet.html#tagged_with/3)
+[`Taglet.tagged_with/4`](https://hexdocs.pm/taglet/Taglet.html#tagged_with/4)
 
 [`Taglet.tagged_with_query/3`](https://hexdocs.pm/taglet/Taglet.html#tagged_with_query/3)

--- a/lib/taglet.ex
+++ b/lib/taglet.ex
@@ -28,7 +28,7 @@ defmodule Taglet do
   It returns the struct with a new entry for the given context.
   """
   @spec add(struct, tags, context, opts) :: struct
-  def add(struct, tags, context \\ "tags", opts \\ [prefix: nil])
+  def add(struct, tags, context \\ "tags", opts \\ [])
   def add(struct, nil, _context, _opts), do: struct
   def add(struct, tag, context, opts) when is_bitstring(tag), do: add(struct, [tag], context, opts)
   def add(struct, tags, context, _opts) when is_list(context), do: add(struct, tags, "tags", context)
@@ -72,7 +72,7 @@ defmodule Taglet do
 
   """
   @spec remove(struct, tag, context, opts) :: struct
-  def remove(struct, tag, context \\ "tags", opts \\ [prefix: nil])
+  def remove(struct, tag, context \\ "tags", opts \\ [])
   def remove(struct, tag, context, opts) when is_list(context), do: remove(struct, tag, "tags", opts)
   def remove(struct, tag, context, opts) do
     tag_list = tag_list(struct, context, opts)
@@ -123,7 +123,7 @@ defmodule Taglet do
   If the old_tag does not exist return nil.
   """
   @spec rename(struct, tag, tag, context, opts) :: nil | struct
-  def rename(struct, old_tag_name, new_tag_name, context, opts \\ [prefix: nil]) do
+  def rename(struct, old_tag_name, new_tag_name, context, opts \\ []) do
     case repo().get_by(Tag, [name: old_tag_name], opts) do
       nil -> nil
       tag -> rename_tag(struct, tag, new_tag_name, context, opts)
@@ -167,7 +167,7 @@ defmodule Taglet do
   - With a module: it returns all the tags associated to one module and context.
   """
   @spec tag_list(taggable, context, opts) :: tag_list
-  def tag_list(taggable, context \\ "tags", opts \\ [prefix: nil]) do
+  def tag_list(taggable, context \\ "tags", opts \\ []) do
     taggable
     |> tag_list_queryable(context)
     |> repo().all(opts)
@@ -200,7 +200,7 @@ defmodule Taglet do
   You can pass a simple tag or a list of tags.
   """
   @spec tagged_with(tags, module, context, opts) :: list
-  def tagged_with(tags, model, context \\ "tags", opts \\ [prefix: nil])
+  def tagged_with(tags, model, context \\ "tags", opts \\ [])
   def tagged_with(tag, model, context, opts) when is_bitstring(tag), do: tagged_with([tag], model, context, opts)
   def tagged_with(tag, model, context, _opts) when is_list(context), do: tagged_with(tag, model, "tags", context)
   def tagged_with(tags, model, context, opts) do

--- a/lib/taglet.ex
+++ b/lib/taglet.ex
@@ -10,11 +10,12 @@ defmodule Taglet do
   package.
   """
 
-  @type taggable            :: module | struct
-  @type tags                :: String.t | list
-  @type tag                 :: String.t
-  @type context             :: String.t
-  @type tag_list            :: list
+  @type taggable  :: module | struct
+  @type tags      :: String.t | list
+  @type tag       :: String.t
+  @type context   :: String.t
+  @type tag_list  :: list
+  @type opts      :: list
 
   @doc """
   Get a persisted struct and inserts a new tag associated to this
@@ -26,30 +27,31 @@ defmodule Taglet do
 
   It returns the struct with a new entry for the given context.
   """
-  @spec add(struct, tags, context) :: struct
-  def add(struct, tags, context \\ "tags")
-  def add(struct, nil, _context), do: struct
-  def add(struct, tag, context) when is_bitstring(tag), do: add(struct, [tag], context)
-  def add(struct, tags, context) do
-    tag_list = tag_list(struct, context)
+  @spec add(struct, tags, context, opts) :: struct
+  def add(struct, tags, context \\ "tags", opts \\ [prefix: nil])
+  def add(struct, nil, _context, _opts), do: struct
+  def add(struct, tag, context, opts) when is_bitstring(tag), do: add(struct, [tag], context, opts)
+  def add(struct, tags, context, _opts) when is_list(context), do: add(struct, tags, "tags", context)
+  def add(struct, tags, context, opts) when is_bitstring(context) do
+    tag_list = tag_list(struct, context, opts)
     new_tags = tags -- tag_list
 
-    add_new_tags(struct, context, new_tags, tag_list)
+    add_new_tags(struct, context, new_tags, tag_list, opts)
   end
 
-  defp add_new_tags(struct, context, [], tag_list), do: put_tags(struct, context, tag_list)
-  defp add_new_tags(struct, context, new_tags, tag_list) do
+  defp add_new_tags(struct, context, [], tag_list, _opts), do: put_tags(struct, context, tag_list)
+  defp add_new_tags(struct, context, new_tags, tag_list, opts) do
     taggings = Enum.map(new_tags, fn(tag) ->
-      generate_tagging(struct, tag, context)
+      generate_tagging(struct, tag, context, opts)
     end)
 
-    repo().insert_all(Tagging, taggings)
+    repo().insert_all(Tagging, taggings, opts)
 
     put_tags(struct, context, tag_list ++ new_tags)
   end
 
-  defp generate_tagging(struct, tag, context) do
-    tag_resource = get_or_create(tag)
+  defp generate_tagging(struct, tag, context, opts) do
+    tag_resource = get_or_create(tag, opts)
 
     %{
       taggable_id: struct.id,
@@ -69,17 +71,19 @@ defmodule Taglet do
   In the same way that add/3 it returns a struct
 
   """
-  @spec remove(struct, tag, context) :: struct
-  def remove(struct, tag, context \\ "tags") do
-    tag_list = tag_list(struct, context)
+  @spec remove(struct, tag, context, opts) :: struct
+  def remove(struct, tag, context \\ "tags", opts \\ [prefix: nil])
+  def remove(struct, tag, context, opts) when is_list(context), do: remove(struct, tag, "tags", opts)
+  def remove(struct, tag, context, opts) do
+    tag_list = tag_list(struct, context, opts)
 
     case tag in tag_list do
       true ->
         struct
-        |> TagletQuery.get_tags_association(get_or_create(tag), context)
-        |> repo().delete_all
+        |> TagletQuery.get_tags_association(get_or_create(tag, opts), context)
+        |> repo().delete_all(opts)
 
-        remove_from_tag_if_unused(tag)
+        remove_from_tag_if_unused(tag, opts )
         put_tags(struct, context, List.delete(tag_list, tag))
       false ->
         put_tags(struct, context, tag_list)
@@ -88,22 +92,22 @@ defmodule Taglet do
   end
 
   # Remove tag from Tag table if it's unused
-  defp remove_from_tag_if_unused(nil), do: nil
-  defp remove_from_tag_if_unused(tag) do
-    tag = repo().get_by(Tag, name: tag)
+  defp remove_from_tag_if_unused(nil, _opts), do: nil
+  defp remove_from_tag_if_unused(tag, opts) do
+    tag = repo().get_by(Tag, [name: tag], opts)
     if tag do
       TagletQuery.count_tagging_by_tag_id(tag.id)
-      |> repo().one
+      |> repo().one(opts)
       |> case do
-        0 -> repo().delete(tag)
+        0 -> repo().delete(tag, opts)
         _ -> nil
       end
     end
   end
 
-  defp get_or_create(tag) do
-    case repo().get_by(Tag, name: tag) do
-      nil -> repo().insert!(%Tag{name: tag})
+  defp get_or_create(tag, opts) do
+    case repo().get_by(Tag, [name: tag], opts) do
+      nil -> repo().insert!(%Tag{name: tag}, opts)
       tag_resource -> tag_resource
     end
   end
@@ -118,39 +122,39 @@ defmodule Taglet do
 
   If the old_tag does not exist return nil.
   """
-  @spec rename(struct, tag, tag, context) :: nil | struct
-  def rename(struct, old_tag_name, new_tag_name, context) do
-    case repo().get_by(Tag, name: old_tag_name) do
+  @spec rename(struct, tag, tag, context, opts) :: nil | struct
+  def rename(struct, old_tag_name, new_tag_name, context, opts \\ [prefix: nil]) do
+    case repo().get_by(Tag, [name: old_tag_name], opts) do
       nil -> nil
-      tag -> rename_tag(struct, tag, new_tag_name, context)
+      tag -> rename_tag(struct, tag, new_tag_name, context, opts)
     end
   end
 
-  defp rename_tag(struct, old_tag, new_tag_name, context) do
-    case taggings_by_tag_id(old_tag.id) do
+  defp rename_tag(struct, old_tag, new_tag_name, context, opts) do
+    case taggings_by_tag_id(old_tag.id, opts) do
       0 ->
         #If the old tag is NOT in Tagging we have only to rename its `name`
         #in Tag table.
         Tag.changeset(old_tag, %{name: new_tag_name})
-        |> repo().update
+        |> repo().update(opts)
       _ ->
         #In this case we have to get or create a new Tag, and uptade all relations
         # context - taggable_type with the new_tag.id
-        new_tag = get_or_create(new_tag_name)
+        new_tag = get_or_create(new_tag_name, opts)
 
         TagletQuery.get_tags_association(struct, old_tag, context)
-        |> repo().update_all(set: [tag_id: new_tag.id])
+        |> repo().update_all([set: [tag_id: new_tag.id]], opts)
 
-        if taggings_by_tag_id(old_tag.id) == 0 do
-          repo().delete(old_tag)
+        if taggings_by_tag_id(old_tag.id, opts) == 0 do
+          repo().delete(old_tag, opts)
         end
     end
   end
 
   #Return the number of entries in Tagging with the tag_id passed as param.
-  defp taggings_by_tag_id(tag_id) do
+  defp taggings_by_tag_id(tag_id, opts) do
     TagletQuery.count_tagging_by_tag_id(tag_id)
-    |> repo().one
+    |> repo().one(opts)
   end
 
   @doc """
@@ -162,11 +166,11 @@ defmodule Taglet do
   - With a struct: it returns the list of tags associated to that struct and context.
   - With a module: it returns all the tags associated to one module and context.
   """
-  @spec tag_list(taggable, context) :: tag_list
-  def tag_list(taggable, context \\ "tags") do
+  @spec tag_list(taggable, context, opts) :: tag_list
+  def tag_list(taggable, context \\ "tags", opts \\ [prefix: nil]) do
     taggable
     |> tag_list_queryable(context)
-    |> repo().all
+    |> repo().all(opts)
   end
 
   @doc """
@@ -195,11 +199,12 @@ defmodule Taglet do
 
   You can pass a simple tag or a list of tags.
   """
-  @spec tagged_with(tags, module, context) :: list
-  def tagged_with(tags, model, context \\ "tags")
-  def tagged_with(tag, model, context) when is_bitstring(tag), do: tagged_with([tag], model, context)
-  def tagged_with(tags, model, context) do
-    do_tags_search(model, tags, context) |> repo().all
+  @spec tagged_with(tags, module, context, opts) :: list
+  def tagged_with(tags, model, context \\ "tags", opts \\ [prefix: nil])
+  def tagged_with(tag, model, context, opts) when is_bitstring(tag), do: tagged_with([tag], model, context, opts)
+  def tagged_with(tag, model, context, _opts) when is_list(context), do: tagged_with(tag, model, "tags", context)
+  def tagged_with(tags, model, context, opts) do
+    do_tags_search(model, tags, context) |> repo().all(opts)
   end
 
   @doc """

--- a/lib/taglet/tag_as.ex
+++ b/lib/taglet/tag_as.ex
@@ -8,7 +8,7 @@ defmodule Taglet.TagAs do
       Module.register_attribute __MODULE__, :contexts, accumulate: true
       @contexts unquote(context)
 
-      def unquote(:"add_#{singularized_context}")(struct, tag) when is_bitstring(tag) do
+      def unquote(:"add_#{singularized_context}")(struct, tag) when is_binary(tag) do
         Taglet.add(struct, tag, unquote(context), [])
       end
       def unquote(:"add_#{singularized_context}")(struct, tag, opts) do
@@ -22,7 +22,7 @@ defmodule Taglet.TagAs do
         Taglet.add(struct, tags, unquote(context), opts)
       end
 
-      def unquote(:"remove_#{singularized_context}")(struct, tag) when is_bitstring(tag) do
+      def unquote(:"remove_#{singularized_context}")(struct, tag) when is_binary(tag) do
         Taglet.remove(struct, tag, unquote(context), [])
       end
       def unquote(:"remove_#{singularized_context}")(struct, tag, opts) do

--- a/lib/taglet/tag_as.ex
+++ b/lib/taglet/tag_as.ex
@@ -8,24 +8,39 @@ defmodule Taglet.TagAs do
       Module.register_attribute __MODULE__, :contexts, accumulate: true
       @contexts unquote(context)
 
-      def unquote(:"add_#{singularized_context}")(struct, tag) do
-        Taglet.add(struct, tag, unquote(context))
+      def unquote(:"add_#{singularized_context}")(struct, tag) when is_bitstring(tag) do
+        Taglet.add(struct, tag, unquote(context), [])
+      end
+      def unquote(:"add_#{singularized_context}")(struct, tag, opts) do
+        Taglet.add(struct, tag, unquote(context), opts)
       end
 
-      def unquote(:"add_#{context}")(struct, tags) do
-        Taglet.add(struct, tags, unquote(context))
+      def unquote(:"add_#{context}")(struct, tags) when not is_list(struct) do
+        Taglet.add(struct, tags, unquote(context), [])
+      end
+      def unquote(:"add_#{context}")(struct, tags, opts) do
+        Taglet.add(struct, tags, unquote(context), opts)
       end
 
-      def unquote(:"remove_#{singularized_context}")(struct, tag) do
-        Taglet.remove(struct, tag, unquote(context))
+      def unquote(:"remove_#{singularized_context}")(struct, tag) when is_bitstring(tag) do
+        Taglet.remove(struct, tag, unquote(context), [])
+      end
+      def unquote(:"remove_#{singularized_context}")(struct, tag, opts) do
+        Taglet.remove(struct, tag, unquote(context), opts)
       end
 
       def unquote(:"#{singularized_context}_list")(struct) do
-        Taglet.tag_list(struct, unquote(context))
+        Taglet.tag_list(struct, unquote(context), [])
+      end
+      def unquote(:"#{singularized_context}_list")(struct, opts) do
+        Taglet.tag_list(struct, unquote(context), opts)
       end
 
       def unquote(:"#{context}")() do
-        Taglet.tag_list(__MODULE__, unquote(context))
+        Taglet.tag_list(__MODULE__, unquote(context), [])
+      end
+      def unquote(:"#{context}")(opts) do
+        Taglet.tag_list(__MODULE__, unquote(context), opts)
       end
 
       def unquote(:"#{context}_queryable")() do
@@ -33,11 +48,17 @@ defmodule Taglet.TagAs do
       end
 
       def unquote(:"tagged_with_#{singularized_context}")(tag) do
-        Taglet.tagged_with(tag, __MODULE__, unquote(context))
+        Taglet.tagged_with(tag, __MODULE__, unquote(context), [])
+      end
+      def unquote(:"tagged_with_#{singularized_context}")(tag, opts) do
+        Taglet.tagged_with(tag, __MODULE__, unquote(context), opts)
       end
 
       def unquote(:"tagged_with_#{context}")(tags) do
-        Taglet.tagged_with(tags, __MODULE__, unquote(context))
+        Taglet.tagged_with(tags, __MODULE__, unquote(context), [])
+      end
+      def unquote(:"tagged_with_#{context}")(tags, opts) do
+        Taglet.tagged_with(tags, __MODULE__, unquote(context), opts)
       end
 
       def unquote(:"tagged_with_query_#{singularized_context}")(queryable, tag) do
@@ -59,19 +80,31 @@ defmodule Taglet.TagAs do
 
         Module.eval_quoted(__MODULE__, quote do
           def unquote(:"add_#{context}")(tags) do
-            Taglet.add(%__MODULE__{}, tags, unquote(context))
+            Taglet.add(%__MODULE__{}, tags, unquote(context), [])
+          end
+          def unquote(:"add_#{context}")(tags, opts) do
+            Taglet.add(%__MODULE__{}, tags, unquote(context), opts)
           end
 
           def unquote(:"add_#{singularized_context}")(tags) do
-            Taglet.add(%__MODULE__{}, tags, unquote(context))
+            Taglet.add(%__MODULE__{}, tags, unquote(context), [])
+          end
+          def unquote(:"add_#{singularized_context}")(tags, opts) do
+            Taglet.add(%__MODULE__{}, tags, unquote(context), opts)
           end
 
           def unquote(:"remove_#{singularized_context}")(tag) do
-            Taglet.remove(%__MODULE__{}, tag, unquote(context))
+            Taglet.remove(%__MODULE__{}, tag, unquote(context), [])
+          end
+          def unquote(:"remove_#{singularized_context}")(tag, opts) do
+            Taglet.remove(%__MODULE__{}, tag, unquote(context), opts)
           end
 
           def unquote(:"rename_#{singularized_context}")(old_tag, new_tag) do
-            Taglet.rename(%__MODULE__{}, old_tag, new_tag, unquote(context) )
+            Taglet.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), [])
+          end
+          def unquote(:"rename_#{singularized_context}")(old_tag, new_tag, opts) do
+            Taglet.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), opts)
           end
         end)
       end)

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Taglet.Mixfile do
     [
       name: :taglet,
       files: ["lib", "mix.exs", "README*", "LICENSE*"],
-      maintainers: ["itsquall", "abmm"],
+      maintainers: ["itsquall", "abmm", "dreamingechoes"],
       licenses: ["Apache License 2.0"],
       links: %{
         "GitHub" => "https://github.com/bizneo/taglet",

--- a/test/taglet/tag_as_test.exs
+++ b/test/taglet/tag_as_test.exs
@@ -1,26 +1,40 @@
 defmodule Taglet.TagAsTest do
-  use ExUnit.Case
-  import Ecto.Query
-
+  alias Ecto.Adapters.SQL
   alias TagletPost, as: Post
   alias Taglet.{Tagging, Tag}
 
-  @repo Taglet.RepoClient.repo
+  import Ecto.Query
+  import Mix.Ecto, only: [build_repo_priv: 1]
+
+  use ExUnit.Case
+
+  @repo       Taglet.RepoClient.repo
+  @tenant_id  "example_tenant"
 
   doctest Taglet
 
   setup do
+    # Regular test
     @repo.delete_all(Post)
     @repo.delete_all(Tagging)
     @repo.delete_all(Tag)
+
+    # Multi tenant test
+    setup_tenant()
+
     on_exit fn ->
+      # Regular test
       @repo.delete_all(Post)
       @repo.delete_all(Tagging)
       @repo.delete_all(Tag)
+
+      # Multi tenant test
+      setup_tenant()
     end
     :ok
   end
 
+  # Regular test
   test "using the module allows to add tags and list it" do
     post = @repo.insert!(%Post{title: "hello world"})
 
@@ -192,4 +206,202 @@ defmodule Taglet.TagAsTest do
     assert Tagging |> @repo.all  |> length == 3
   end
 
+  # Multi tenant test
+  test "[multi tenant] using the module allows to add tags and list it" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+
+    result = Post.add_categories(post, ["mycategory", "yourcategory"], [prefix: @tenant_id])
+
+    assert result.categories == ["mycategory", "yourcategory"]
+  end
+
+  test "[multi tenant] using the module allows to add tags and list it as a queryable" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+
+    Post.add_categories(post, ["mycategory", "yourcategory"], [prefix: @tenant_id])
+    queryable = Post.categories_queryable
+
+    assert queryable.__struct__ == Ecto.Query
+    assert queryable |> @repo.all([prefix: @tenant_id]) == ["mycategory", "yourcategory"]
+    assert queryable |> @repo.all == []
+  end
+
+  test "[multi tenant] using the module allows to add a tag and list it" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Post.add_category(post, "mycategory", [prefix: @tenant_id])
+
+    result = Post.category_list(post, [prefix: @tenant_id])
+
+    assert result == ["mycategory"]
+  end
+
+  test "[multi tenant] using the module allows to add a tag and list it for different contexts" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Post.add_category(post, "mycategory", [prefix: @tenant_id])
+    Post.add_tag(post, "mytag", [prefix: @tenant_id])
+
+    tag_result      = Post.tag_list(post, [prefix: @tenant_id])
+    category_result = Post.category_list(post, [prefix: @tenant_id])
+
+    assert tag_result      == ["mytag"]
+    assert category_result == ["mycategory"]
+  end
+
+  test "[multi tenant] using the module allows to add a tag and list it as queryable for different contexts" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Post.add_category(post, "mycategory", [prefix: @tenant_id])
+    Post.add_tag(post, "mytag", [prefix: @tenant_id])
+
+    tag_queryable      = Post.tags_queryable
+    category_queryable = Post.categories_queryable
+
+    assert tag_queryable.__struct__      == Ecto.Query
+    assert category_queryable.__struct__ == Ecto.Query
+
+    assert tag_queryable |> @repo.all      == []
+    assert category_queryable |> @repo.all == []
+    assert tag_queryable |> @repo.all([prefix: @tenant_id])      == ["mytag"]
+    assert category_queryable |> @repo.all([prefix: @tenant_id]) == ["mycategory"]
+  end
+
+  test "[multi tenant] Remove only a Tag relation" do
+    post1 = @repo.insert!(%Post{title: "Post1"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "Post2"}, [prefix: @tenant_id])
+    #We add a category without relations
+    Post.add_category("public", [prefix: @tenant_id])
+    #Now we add 2 new entries in Tagging relating with different tag_id
+    Post.add_category(post1, "public", [prefix: @tenant_id])
+    Post.add_category(post2, "public", [prefix: @tenant_id])
+    #Remove only the relation with post1
+    result = Post.remove_category(post1, "public", [prefix: @tenant_id])
+    # Tag still exits but there are 2 relations in Tagging that represent
+    # a general relation with Post - categories and one for post2
+    assert result.categories == []
+    assert Post.categories([prefix: @tenant_id]) == ["public"]
+    assert Tag |> @repo.all |> length == 0
+    assert Tagging |> @repo.all |> length == 0
+    assert Tag |> @repo.all([prefix: @tenant_id]) |> length == 1
+    assert Tagging |> @repo.all([prefix: @tenant_id]) |> length == 2
+  end
+
+  test "[multi tenant] It is possible to remove a Tag and all its relations" do
+    post = @repo.insert!(%Post{title: "Post1"}, [prefix: @tenant_id])
+    #We add a category without relations
+    Post.add_category("public", [prefix: @tenant_id])
+    #Now we add a new entry in Tagging relating Tag and taggable_id
+    Post.add_category(post, "public", [prefix: @tenant_id])
+    #Remove everything about public - Post - categories
+    result = Post.remove_category("public", [prefix: @tenant_id])
+
+    assert result.categories == []
+    assert Tag |> @repo.all([prefix: @tenant_id]) == []
+    assert Tagging |> @repo.all([prefix: @tenant_id]) == []
+  end
+
+  test "[multi tenant] Remove a generic Tag keep other contexts" do
+    post = @repo.insert!(%Post{title: "Post1"}, [prefix: @tenant_id])
+    #We add two categories in a general way (without relations)
+    Post.add_category("public", [prefix: @tenant_id])
+    Post.add_tag("private", [prefix: @tenant_id])
+    #Now we add 2 new entries in Tagging relating Tag and taggable_id
+    Post.add_category(post, "public", [prefix: @tenant_id])
+    Post.add_tag(post, "private", [prefix: @tenant_id])
+    #At this point we have 2 tags in Tag, and 4 entries in Tagging
+    result = Post.remove_category("public", [prefix: @tenant_id])
+
+    #Remove everything about public - Post - categories
+    assert result.categories == []
+    assert Post.categories([prefix: @tenant_id]) == []
+    assert Post.tags([prefix: @tenant_id]) == ["private"]
+    assert Tagging |> @repo.all([prefix: @tenant_id]) |> length == 2
+  end
+
+  test "[multi tenant] using the module allows to search for all created tags for a context" do
+    post1 = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    Taglet.add(post1, ["tag1", "tag2"], [prefix: @tenant_id])
+    Taglet.add(post2, ["tag2", "tag3"], [prefix: @tenant_id])
+
+    result = Post.tags([prefix: @tenant_id])
+
+    assert result == ["tag1", "tag2", "tag3"]
+  end
+
+  test "[multi tenant] using the module allows to search for tagged resources" do
+    post1 = @repo.insert!(%Post{title: "hello world1"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    post3 = @repo.insert!(%Post{title: "hello world3"}, [prefix: @tenant_id])
+    Post.add_category(post1, "tagged1", [prefix: @tenant_id])
+    Post.add_category(post2, "tagged1", [prefix: @tenant_id])
+    Post.add_category(post3, "tagged2", [prefix: @tenant_id])
+    post1 = @repo.get(Post, 1, [prefix: @tenant_id])
+    post2 = @repo.get(Post, 2, [prefix: @tenant_id])
+
+    result = Post.tagged_with_category("tagged1", [prefix: @tenant_id])
+
+    assert result == [post1, post2]
+  end
+
+  test "[multi tenant] using the module allows to build a query to search for tagged resources" do
+    post1 = @repo.insert!(%Post{title: "hello world1"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    post3 = @repo.insert!(%Post{title: "hello world3"}, [prefix: @tenant_id])
+    Post.add_category(post1, "tagged1", [prefix: @tenant_id])
+    Post.add_category(post2, "tagged1", [prefix: @tenant_id])
+    Post.add_category(post3, "tagged2", [prefix: @tenant_id])
+    query = Post |> where(title: "hello world1")
+    post1 = @repo.get(Post, 1, [prefix: @tenant_id])
+
+    result = Post.tagged_with_query_category(query, "tagged1") |> @repo.all([prefix: @tenant_id])
+
+    assert result == [post1]
+  end
+
+  test "[multi tenant] Update a tag name without relations" do
+
+    Post.add_category(["public"], [prefix: @tenant_id])
+    assert Post.categories([prefix: @tenant_id]) == ["public"]
+
+    #Now we add 2 new entries in Tagging relating Tag and taggable_id
+    Post.rename_category("public", "public_post", [prefix: @tenant_id])
+
+    assert Post.categories == []
+    assert Tag |> @repo.all |> length == 0
+    assert Tagging |> @repo.all |> length == 0
+    assert Post.categories([prefix: @tenant_id]) == ["public_post"]
+    assert Tag |> @repo.all([prefix: @tenant_id]) |> length == 1
+    assert Tagging |> @repo.all([prefix: @tenant_id]) |> length == 1
+  end
+
+  test "[multi tenant] Update a tag name with relations and different contexts" do
+    Post.add_categories(["public", "private"], [prefix: @tenant_id])
+    Post.add_tags(["private"], [prefix: @tenant_id])
+
+    assert Post.categories([prefix: @tenant_id]) == ["private", "public"]
+    assert Post.tags([prefix: @tenant_id]) == ["private"]
+
+    #Now we add 2 new entries in Tagging relating Tag and taggable_id
+    Post.rename_category("private", "private_category", [prefix: @tenant_id])
+
+    assert Post.categories == []
+    assert Post.tags == []
+    assert Tag |> @repo.all |> length == 0
+    assert Tagging |> @repo.all |> length == 0
+    assert Post.categories([prefix: @tenant_id]) == ["private_category", "public"]
+    assert Post.tags([prefix: @tenant_id]) == ["private"]
+    assert Tag |> @repo.all([prefix: @tenant_id]) |> length == 3
+    assert Tagging |> @repo.all([prefix: @tenant_id]) |> length == 3
+  end
+
+  # Aux functions
+  defp setup_tenant do
+    migrations_path = Path.join(build_repo_priv(@repo), "migrations")
+
+    # Drop the previous tenant to reset the data
+    SQL.query(@repo, "DROP SCHEMA \"#{@tenant_id}\" CASCADE", [])
+
+    # Create new tenant
+    SQL.query(@repo, "CREATE SCHEMA \"#{@tenant_id}\"", [])
+    Ecto.Migrator.run(@repo, migrations_path, :up, [prefix: @tenant_id, all: true])
+  end
 end

--- a/test/taglet_test.exs
+++ b/test/taglet_test.exs
@@ -1,27 +1,42 @@
 defmodule TagletTest do
-  use ExUnit.Case
-  import Ecto.Query
-
+  alias Ecto.Adapters.SQL
   alias TagletPost, as: Post
   alias Taglet.{Tagging, Tag}
 
-  @repo Taglet.RepoClient.repo
+  import Ecto.Query
+  import Ecto.Query
+  import Mix.Ecto, only: [build_repo_priv: 1]
+
+  use ExUnit.Case
+
+  @repo       Taglet.RepoClient.repo
+  @tenant_id  "example_tenant"
 
   doctest Taglet
 
   setup do
+    # Regular test
     @repo.delete_all(Post)
     @repo.delete_all(Tagging)
     @repo.delete_all(Tag)
+
+    # Multi tenant test
+    setup_tenant()
+
     on_exit fn ->
+      # Regular test
       @repo.delete_all(Post)
       @repo.delete_all(Tagging)
       @repo.delete_all(Tag)
+
+      # Multi tenant test
+      setup_tenant()
     end
     :ok
   end
 
-  test "add/3 with a tag returns the struct with the new tag" do
+  # Regular test
+  test "add/4 with a tag returns the struct with the new tag" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag")
 
@@ -30,7 +45,7 @@ defmodule TagletTest do
     assert result.tags == ["mytag", "tag1"]
   end
 
-  test "add/3 with a tag list returns the struct with the new tags" do
+  test "add/4 with a tag list returns the struct with the new tags" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag")
 
@@ -39,7 +54,7 @@ defmodule TagletTest do
     assert result.tags == ["mytag", "tag1", "tag2"]
   end
 
-  test "add/3 with context returns a diferent list for every context" do
+  test "add/4 with context returns a diferent list for every context" do
     post = @repo.insert!(%Post{title: "hello world"})
 
     result1 = Taglet.add(post, "mytag1", "context1")
@@ -49,7 +64,7 @@ defmodule TagletTest do
     assert result2.context2 == ["mytag2"]
   end
 
-  test "add/3 with repeated tag returns the same tags" do
+  test "add/4 with repeated tag returns the same tags" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag")
 
@@ -58,13 +73,13 @@ defmodule TagletTest do
     assert result.tags == ["mytag"]
   end
 
-  test "add/3 with nil tag returns the same struct" do
+  test "add/4 with nil tag returns the same struct" do
     post = @repo.insert!(%Post{title: "hello world"})
     result = Taglet.add(post, nil)
     assert result == post
   end
 
-  test "remove/3 deletes a tag and returns a list of associated tags" do
+  test "remove/4 deletes a tag and returns a list of associated tags" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag")
     Taglet.add(post, "mytag2")
@@ -75,7 +90,7 @@ defmodule TagletTest do
     assert result.tags == ["mytag", "mytag3"]
   end
 
-  test "remove/3 deletes a tag for a specific context and returns a list of associated tags" do
+  test "remove/4 deletes a tag for a specific context and returns a list of associated tags" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag", "context1")
     Taglet.add(post, "mytag2", "context1")
@@ -86,7 +101,7 @@ defmodule TagletTest do
     assert result.context1 == ["mytag"]
   end
 
-  test "remove/3 does nothing for an unexistent tag" do
+  test "remove/4 does nothing for an unexistent tag" do
     post = @repo.insert!(%Post{title: "hello world"})
     Taglet.add(post, "mytag")
     Taglet.add(post, "mytag2")
@@ -128,7 +143,7 @@ defmodule TagletTest do
     assert result == ["tag1", "tag2", "tag3"]
   end
 
-  test "tagged_with/3 returns a list of structs associated to a tag" do
+  test "tagged_with/4 returns a list of structs associated to a tag" do
     post1 = @repo.insert!(%Post{title: "hello world1"})
     post2 = @repo.insert!(%Post{title: "hello world2"})
     post3 = @repo.insert!(%Post{title: "hello world3"})
@@ -141,7 +156,7 @@ defmodule TagletTest do
     assert result == [post1, post2]
   end
 
-  test "tagged_with_query/3 returns a query of structs associated to a tag" do
+  test "tagged_with_query/4 returns a query of structs associated to a tag" do
     post1 = @repo.insert!(%Post{title: "hello world1"})
     post2 = @repo.insert!(%Post{title: "hello world2"})
     post3 = @repo.insert!(%Post{title: "hello world3"})
@@ -153,5 +168,157 @@ defmodule TagletTest do
     result = Taglet.tagged_with_query(query, ["tagged1", "tagged2"]) |> @repo.all
 
     assert result == [post2]
+  end
+
+  # Multi tenant test
+  test "[multi tenant] add/4 with a tag returns the struct with the new tag" do
+    post = @repo.insert!(%Post{title: "hello world"})
+    Taglet.add(post, "mytag")
+
+    result = Taglet.add(post, "tag1")
+
+    assert result.tags == ["mytag", "tag1"]
+  end
+
+  test "[multi tenant] add/4 with a tag list returns the struct with the new tags" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", [prefix: @tenant_id])
+
+    result = Taglet.add(post, ["tag1", "tag2"], [prefix: @tenant_id])
+
+    assert result.tags == ["mytag", "tag1", "tag2"]
+  end
+
+  test "[multi tenant] add/4 with context returns a diferent list for every context" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+
+    result1 = Taglet.add(post, "mytag1", "context1", [prefix: @tenant_id])
+    result2 = Taglet.add(post, "mytag2", "context2", [prefix: @tenant_id])
+
+    assert result1.context1 == ["mytag1"]
+    assert result2.context2 == ["mytag2"]
+  end
+
+  test "[multi tenant] add/4 with repeated tag returns the same tags" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", [prefix: @tenant_id])
+
+    result = Taglet.add(post, "mytag", [prefix: @tenant_id])
+
+    assert result.tags == ["mytag"]
+  end
+
+  test "[multi tenant] add/4 with nil tag returns the same struct" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    result = Taglet.add(post, nil, [prefix: @tenant_id])
+    assert result == post
+  end
+
+  test "[multi tenant] remove/4 deletes a tag and returns a list of associated tags" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", "tags", [prefix: @tenant_id])
+    Taglet.add(post, "mytag2", "tags", [prefix: @tenant_id])
+    Taglet.add(post, "mytag3", "tags", [prefix: @tenant_id])
+
+    result = Taglet.remove(post, "mytag2", "tags", [prefix: @tenant_id])
+
+    assert result.tags == ["mytag", "mytag3"]
+  end
+
+  test "[multi tenant] remove/4 deletes a tag for a specific context and returns a list of associated tags" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", "context1", [prefix: @tenant_id])
+    Taglet.add(post, "mytag2", "context1", [prefix: @tenant_id])
+    Taglet.add(post, "mytag3", "context2", [prefix: @tenant_id])
+
+    result = Taglet.remove(post, "mytag2", "context1", [prefix: @tenant_id])
+
+    assert result.context1 == ["mytag"]
+  end
+
+  test "[multi tenant] remove/4 does nothing for an unexistent tag" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", "tags", [prefix: @tenant_id])
+    Taglet.add(post, "mytag2", "tags", [prefix: @tenant_id])
+    Taglet.add(post, "mytag3", "tags", [prefix: @tenant_id])
+
+    result = Taglet.remove(post, "my2", "tags", [prefix: @tenant_id])
+
+    assert result.tags() == ["mytag", "mytag2", "mytag3"]
+  end
+
+  test "[multi tenant] tag_list/2 with struct as param returns a list of associated tags" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", "tags", [prefix: @tenant_id])
+    Taglet.add(post, "mytag2", "tags", [prefix: @tenant_id])
+
+    result = Taglet.tag_list(post, "tags", [prefix: @tenant_id])
+
+    assert result == ["mytag", "mytag2"]
+  end
+
+  test "[multi tenant] tag_list/2 with struct returns a list of associated tags for a specific context" do
+    post = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    Taglet.add(post, "mytag", "context", [prefix: @tenant_id])
+    Taglet.add(post, "mytag2", "context", [prefix: @tenant_id])
+
+    result = Taglet.tag_list(post, "context", [prefix: @tenant_id])
+
+    assert result == ["mytag", "mytag2"]
+  end
+
+  test "[multi tenant] tag_list/2 with module as param returns a list of tags related with one context and module" do
+    post1 = @repo.insert!(%Post{title: "hello world"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    Taglet.add(post1, ["tag1", "tag2"], "tags", [prefix: @tenant_id])
+    Taglet.add(post2, ["tag2", "tag3"], "tags", [prefix: @tenant_id])
+
+    result = Taglet.tag_list(Post, "tags", [prefix: @tenant_id])
+
+    assert result == ["tag1", "tag2", "tag3"]
+  end
+
+  test "[multi tenant] tagged_with/4 returns a list of structs associated to a tag" do
+    post1 = @repo.insert!(%Post{title: "hello world1"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    post3 = @repo.insert!(%Post{title: "hello world3"}, [prefix: @tenant_id])
+    Taglet.add(post1, "tagged1", "tags", [prefix: @tenant_id])
+    Taglet.add(post2, "tagged1", "tags", [prefix: @tenant_id])
+    Taglet.add(post3, "tagged2", "tags", [prefix: @tenant_id])
+    post1 = @repo.get(Post, 1, [prefix: @tenant_id])
+    post2 = @repo.get(Post, 2, [prefix: @tenant_id])
+
+    result = Taglet.tagged_with("tagged1", Post, "tags", [prefix: @tenant_id])
+
+    assert result == [post1, post2]
+  end
+
+  test "[multi tenant] tagged_with_query/4 returns a query of structs associated to a tag" do
+    post1 = @repo.insert!(%Post{title: "hello world1"}, [prefix: @tenant_id])
+    post2 = @repo.insert!(%Post{title: "hello world2"}, [prefix: @tenant_id])
+    post3 = @repo.insert!(%Post{title: "hello world3"}, [prefix: @tenant_id])
+    Taglet.add(post1, "tagged1", "tags", [prefix: @tenant_id])
+    Taglet.add(post2, ["tagged1", "tagged2"], "tags", [prefix: @tenant_id])
+    Taglet.add(post3, "tagged2", "tags", [prefix: @tenant_id])
+    query = Post |> where(title: "hello world2")
+    post2 = @repo.get(Post, 2, [prefix: @tenant_id])
+
+    result =
+      Taglet.tagged_with_query(query, ["tagged1", "tagged2"])
+      |> @repo.all([prefix: @tenant_id])
+
+    assert result == [post2]
+  end
+
+  # Aux functions
+  defp setup_tenant do
+    migrations_path = Path.join(build_repo_priv(@repo), "migrations")
+
+    # Drop the previous tenant to reset the data
+    SQL.query(@repo, "DROP SCHEMA \"#{@tenant_id}\" CASCADE", [])
+
+    # Create new tenant
+    SQL.query(@repo, "CREATE SCHEMA \"#{@tenant_id}\"", [])
+    Ecto.Migrator.run(@repo, migrations_path, :up, [prefix: @tenant_id, all: true])
   end
 end


### PR DESCRIPTION
Connects with #5.

Adds new opts param to the library functions in order to send `prefix` attribute to the `Repo` calls.